### PR TITLE
Set default location with westus.

### DIFF
--- a/.github/workflows/setupOpenLibertyAks.yml
+++ b/.github/workflows/setupOpenLibertyAks.yml
@@ -55,7 +55,7 @@ jobs:
 
           location=${{ github.event.inputs.region }}
           if [[ -z "${location}" ]];then
-            location=eastus
+            location=westus
           fi
 
           disambiguationSuffix=${{ github.event.inputs.disambiguationSuffix }}


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/setupOpenLibertyAks.yml` file. The change updates the default value for the `location` variable.

* [`.github/workflows/setupOpenLibertyAks.yml`](diffhunk://#diff-3f4bc26cd9318a00aac5bb55c286068bef6e18016bf5784ae35abddf2c3a7716L58-R58): Changed the default `location` from `eastus` to `westus`.