### PR TITLE
[Bugfix]Change version extraction method and add bash shebangs to scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If you see a warning about being in 'detached HEAD' state, it is safe to ignore.
 
 ```bash
 cd ${DIR}/azure.liberty.aks
-export VERSION=$(mvn help:evaluate -Dexpression=project.parent.version -q -DforceStdout | grep -v '^\[' | tr -d '\r')
+export VERSION=$(grep -A4 "<parent>" pom.xml | grep "<version>" | awk -F'[<>]' '{print $3}')
 
 cd ${DIR}
 curl -L -o ${DIR}/azure-javaee-iaas-parent-${VERSION}.pom  \

--- a/azd-hooks/postdeploy.sh
+++ b/azd-hooks/postdeploy.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 export GATEWAY_PUBLICIP_ID=$(az network application-gateway list \
   --resource-group ${RESOURCE_GROUP_NAME} \
   --query '[0].frontendIPConfigurations[0].publicIPAddress.id' -o tsv)

--- a/azd-hooks/postprovision.sh
+++ b/azd-hooks/postprovision.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # if folder tmp-build exists, delete the folder
 if [ -d "tmp-build" ];
   then rm -rf tmp-build;

--- a/azd-hooks/preprovision.sh
+++ b/azd-hooks/preprovision.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 az extension add --upgrade -n application-insights
 source .scripts/setup-env-variables-template.sh
 
@@ -10,7 +12,7 @@ git clone https://github.com/WASdev/azure.liberty.aks ${DIR}/azure.liberty.aks
 
 cd ${DIR}/azure.liberty.aks
 git checkout ${LIBERTY_AKS_REPO_REF}
-export VERSION=$(mvn help:evaluate -Dexpression=project.parent.version -q -DforceStdout | grep -v '^\[' | tr -d '\r')
+export VERSION=$(grep -A4 "<parent>" pom.xml | grep "<version>" | awk -F'[<>]' '{print $3}')
 
 cd ${DIR}
 curl -L -o ${DIR}/azure-javaee-iaas-parent-${VERSION}.pom  \


### PR DESCRIPTION
## Context
Refer to [6199](https://dev.azure.com/edburns-msft/Open%20Standard%20Enterprise%20Java%20(Java%20EE)%20on%20Azure/_workitems/edit/6199)


This pull request includes several updates to various shell scripts and the `README.md` file to improve version extraction and ensure proper script execution. 


```diff
- export VERSION=$(mvn help:evaluate -Dexpression=project.parent.version -q -DforceStdout | grep -v '^\[' | tr -d '\r')
+ export VERSION=$(grep -A4 "<parent>" pom.xml | grep "<version>" | awk -F'[<>]' '{print $3}')
```

The usage of maven command to get the version is not appropriate here, as it requires downloading the corresponding version of the dependency first, and this dependency cannot be downloaded because it's in the github packages repository, which can't be download directly.


## Updates

Version extraction improvement:

- Changed the method for extracting the project version from Maven to use `grep` and `awk` for better reliability.

Script execution enhancement:

* Added a shebang line to ensure the script runs with the correct interpreter.
