### PR TITLE
Remove condition for deploying only supporting resources.

### DIFF
--- a/.github/workflows/setupOpenLibertyAks.yml
+++ b/.github/workflows/setupOpenLibertyAks.yml
@@ -155,7 +155,6 @@ jobs:
   deploy-openliberty-on-aks:
     needs: preflight
     runs-on: ubuntu-20.04
-    if: ${{ inputs.deployRequiredSupportingResourcesOnly == 'false' }}
     steps:
       - name: Checkout ${{ env.aksRepoUserName }}/azure.liberty.aks
         uses: actions/checkout@v2
@@ -244,7 +243,6 @@ jobs:
   deploy-azure-monitor:
     needs: [preflight, deploy-openliberty-on-aks]
     runs-on: ubuntu-20.04
-    if: ${{ inputs.deployRequiredSupportingResourcesOnly == 'false' }}
     steps:
       - uses: azure/login@v1
         id: azure-login
@@ -292,7 +290,6 @@ jobs:
   deploy-cargo-tracker:
     needs: [preflight, deploy-db,deploy-azure-monitor]
     runs-on: ubuntu-20.04
-    if: ${{ inputs.deployRequiredSupportingResourcesOnly == 'false' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/setupOpenLibertyAks.yml` file to streamline the deployment process by removing conditional checks for deploying supporting resources.

Changes to deployment workflows:

* [`.github/workflows/setupOpenLibertyAks.yml`](diffhunk://#diff-3f4bc26cd9318a00aac5bb55c286068bef6e18016bf5784ae35abddf2c3a7716L158): Removed the `if` conditions that checked `inputs.deployRequiredSupportingResourcesOnly` 