### PR TITLE
Fix JMS issue: The message endpoint for the ***Consumer message-driven bean cannot be activated 

### DIFF
--- a/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/CargoHandledConsumer.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/CargoHandledConsumer.java
@@ -25,7 +25,7 @@ import org.eclipse.cargotracker.domain.model.cargo.TrackingId;
           propertyValue = "jakarta.jms.Queue"),
       @ActivationConfigProperty(
           propertyName = "destinationLookup",
-          propertyValue = "jms/CargoHandledQueue")
+          propertyValue = "java:app/jms/CargoHandledQueue")
     })
 public class CargoHandledConsumer implements MessageListener {
 

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/CargoHandledConsumer.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/CargoHandledConsumer.java
@@ -25,7 +25,7 @@ import org.eclipse.cargotracker.domain.model.cargo.TrackingId;
           propertyValue = "jakarta.jms.Queue"),
       @ActivationConfigProperty(
           propertyName = "destinationLookup",
-          propertyValue = "java:app/jms/CargoHandledQueue")
+          propertyValue = "jms/CargoHandledQueue")
     })
 public class CargoHandledConsumer implements MessageListener {
 

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/DeliveredCargoConsumer.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/DeliveredCargoConsumer.java
@@ -16,7 +16,7 @@ import jakarta.jms.MessageListener;
           propertyValue = "jakarta.jms.Queue"),
       @ActivationConfigProperty(
           propertyName = "destinationLookup",
-          propertyValue = "jms/DeliveredCargoQueue")
+          propertyValue = "java:app/jms/DeliveredCargoQueue")
     })
 public class DeliveredCargoConsumer implements MessageListener {
 

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/DeliveredCargoConsumer.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/DeliveredCargoConsumer.java
@@ -16,7 +16,7 @@ import jakarta.jms.MessageListener;
           propertyValue = "jakarta.jms.Queue"),
       @ActivationConfigProperty(
           propertyName = "destinationLookup",
-          propertyValue = "java:app/jms/DeliveredCargoQueue")
+          propertyValue = "jms/DeliveredCargoQueue")
     })
 public class DeliveredCargoConsumer implements MessageListener {
 

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/HandlingEventRegistrationAttemptConsumer.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/HandlingEventRegistrationAttemptConsumer.java
@@ -19,7 +19,7 @@ import org.eclipse.cargotracker.interfaces.handling.HandlingEventRegistrationAtt
           propertyValue = "jakarta.jms.Queue"),
       @ActivationConfigProperty(
           propertyName = "destinationLookup",
-          propertyValue = "jms/HandlingEventRegistrationAttemptQueue")
+          propertyValue = "java:app/jms/HandlingEventRegistrationAttemptQueue")
     })
 public class HandlingEventRegistrationAttemptConsumer implements MessageListener {
 

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/HandlingEventRegistrationAttemptConsumer.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/HandlingEventRegistrationAttemptConsumer.java
@@ -19,7 +19,7 @@ import org.eclipse.cargotracker.interfaces.handling.HandlingEventRegistrationAtt
           propertyValue = "jakarta.jms.Queue"),
       @ActivationConfigProperty(
           propertyName = "destinationLookup",
-          propertyValue = "java:app/jms/HandlingEventRegistrationAttemptQueue")
+          propertyValue = "jms/HandlingEventRegistrationAttemptQueue")
     })
 public class HandlingEventRegistrationAttemptConsumer implements MessageListener {
 

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/JmsApplicationEvents.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/JmsApplicationEvents.java
@@ -20,16 +20,16 @@ public class JmsApplicationEvents implements ApplicationEvents, Serializable {
   private static final int LOW_PRIORITY = 0;
   @Inject JMSContext jmsContext;
 
-  @Resource(lookup = "java:app/jms/CargoHandledQueue")
+  @Resource(lookup = "jms/CargoHandledQueue")
   private Destination cargoHandledQueue;
 
-  @Resource(lookup = "java:app/jms/MisdirectedCargoQueue")
+  @Resource(lookup = "jms/MisdirectedCargoQueue")
   private Destination misdirectedCargoQueue;
 
-  @Resource(lookup = "java:app/jms/DeliveredCargoQueue")
+  @Resource(lookup = "jms/DeliveredCargoQueue")
   private Destination deliveredCargoQueue;
 
-  @Resource(lookup = "java:app/jms/HandlingEventRegistrationAttemptQueue")
+  @Resource(lookup = "jms/HandlingEventRegistrationAttemptQueue")
   private Destination handlingEventQueue;
 
   @Inject private Logger logger;

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/JmsApplicationEvents.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/JmsApplicationEvents.java
@@ -20,16 +20,16 @@ public class JmsApplicationEvents implements ApplicationEvents, Serializable {
   private static final int LOW_PRIORITY = 0;
   @Inject JMSContext jmsContext;
 
-  @Resource(lookup = "jms/CargoHandledQueue")
+  @Resource(lookup = "java:app/jms/CargoHandledQueue")
   private Destination cargoHandledQueue;
 
-  @Resource(lookup = "jms/MisdirectedCargoQueue")
+  @Resource(lookup = "java:app/jms/MisdirectedCargoQueue")
   private Destination misdirectedCargoQueue;
 
-  @Resource(lookup = "jms/DeliveredCargoQueue")
+  @Resource(lookup = "java:app/jms/DeliveredCargoQueue")
   private Destination deliveredCargoQueue;
 
-  @Resource(lookup = "jms/HandlingEventRegistrationAttemptQueue")
+  @Resource(lookup = "java:app/jms/HandlingEventRegistrationAttemptQueue")
   private Destination handlingEventQueue;
 
   @Inject private Logger logger;

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/MisdirectedCargoConsumer.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/MisdirectedCargoConsumer.java
@@ -16,7 +16,7 @@ import jakarta.jms.MessageListener;
           propertyValue = "jakarta.jms.Queue"),
       @ActivationConfigProperty(
           propertyName = "destinationLookup",
-          propertyValue = "java:app/jms/MisdirectedCargoQueue")
+          propertyValue = "jms/MisdirectedCargoQueue")
     })
 public class MisdirectedCargoConsumer implements MessageListener {
 

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/MisdirectedCargoConsumer.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/MisdirectedCargoConsumer.java
@@ -16,7 +16,7 @@ import jakarta.jms.MessageListener;
           propertyValue = "jakarta.jms.Queue"),
       @ActivationConfigProperty(
           propertyName = "destinationLookup",
-          propertyValue = "jms/MisdirectedCargoQueue")
+          propertyValue = "java:app/jms/MisdirectedCargoQueue")
     })
 public class MisdirectedCargoConsumer implements MessageListener {
 

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/RejectedRegistrationAttemptsConsumer.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/RejectedRegistrationAttemptsConsumer.java
@@ -16,7 +16,7 @@ import jakarta.jms.MessageListener;
           propertyValue = "jakarta.jms.Queue"),
       @ActivationConfigProperty(
           propertyName = "destinationLookup",
-          propertyValue = "jms/RejectedRegistrationAttemptsQueue")
+          propertyValue = "java:app/jms/RejectedRegistrationAttemptsQueue")
     })
 public class RejectedRegistrationAttemptsConsumer implements MessageListener {
 

--- a/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/RejectedRegistrationAttemptsConsumer.java
+++ b/src/main/java/org/eclipse/cargotracker/infrastructure/messaging/jms/RejectedRegistrationAttemptsConsumer.java
@@ -16,7 +16,7 @@ import jakarta.jms.MessageListener;
           propertyValue = "jakarta.jms.Queue"),
       @ActivationConfigProperty(
           propertyName = "destinationLookup",
-          propertyValue = "java:app/jms/RejectedRegistrationAttemptsQueue")
+          propertyValue = "jms/RejectedRegistrationAttemptsQueue")
     })
 public class RejectedRegistrationAttemptsConsumer implements MessageListener {
 

--- a/src/main/java/org/eclipse/cargotracker/interfaces/booking/sse/RealtimeCargoTrackingService.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/booking/sse/RealtimeCargoTrackingService.java
@@ -46,7 +46,7 @@ public class RealtimeCargoTrackingService {
     public void tracking(@Context SseEventSink eventSink) {
         synchronized (RealtimeCargoTrackingService.class) {
             try {
-                String name = "java:app/jms/CargoHandledQueue";
+                String name = "jms/CargoHandledQueue";
                 InitialContext ctx = new InitialContext();
                 Object obj = InitialContext.doLookup(name);
             } catch (NamingException e) {

--- a/src/main/java/org/eclipse/cargotracker/interfaces/booking/sse/RealtimeCargoTrackingService.java
+++ b/src/main/java/org/eclipse/cargotracker/interfaces/booking/sse/RealtimeCargoTrackingService.java
@@ -46,7 +46,7 @@ public class RealtimeCargoTrackingService {
     public void tracking(@Context SseEventSink eventSink) {
         synchronized (RealtimeCargoTrackingService.class) {
             try {
-                String name = "jms/CargoHandledQueue";
+                String name = "java:app/jms/CargoHandledQueue";
                 InitialContext ctx = new InitialContext();
                 Object obj = InitialContext.doLookup(name);
             } catch (NamingException e) {

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -95,18 +95,18 @@
                maxQueueDepth="5000" />
     </messagingEngine>
 
-    <jmsQueueConnectionFactory connectionManagerRef="CargoCM" jndiName="jms/QueueConnectionFactory">
+    <jmsQueueConnectionFactory connectionManagerRef="CargoCM" jndiName="java:app/jms/QueueConnectionFactory">
     </jmsQueueConnectionFactory>
 
-    <jmsQueue id="CargoHandledQueue" jndiName="jms/CargoHandledQueue">
+    <jmsQueue id="CargoHandledQueue" jndiName="java:app/jms/CargoHandledQueue">
         <properties.wasJms queueName="CargoHandledQueue"/>
     </jmsQueue>
 
     <jmsActivationSpec id="cargo-tracker/CargoHandledConsumer">
-        <properties.wasJms destinationLookup="jms/CargoHandledQueue" destinationRef="CargoHandledQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
+        <properties.wasJms destinationLookup="java:app/jms/CargoHandledQueue" destinationRef="CargoHandledQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
     </jmsActivationSpec>  
 
-    <jmsQueue id="MisdirectedCargoQueue" jndiName="jms/MisdirectedCargoQueue">
+    <jmsQueue id="MisdirectedCargoQueue" jndiName="java:app/jms/MisdirectedCargoQueue">
         <properties.wasJms queueName="MisdirectedCargoQueue"/>
     </jmsQueue>
 
@@ -114,7 +114,7 @@
         <properties.wasJms destinationRef="MisdirectedCargoQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
     </jmsActivationSpec>  
 
-    <jmsQueue id="DeliveredCargoQueue" jndiName="jms/DeliveredCargoQueue">
+    <jmsQueue id="DeliveredCargoQueue" jndiName="java:app/jms/DeliveredCargoQueue">
         <properties.wasJms queueName="DeliveredCargoQueue"/>
     </jmsQueue>
 
@@ -122,7 +122,7 @@
         <properties.wasJms destinationRef="DeliveredCargoQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
     </jmsActivationSpec>  
 
-    <jmsQueue id="HandlingEventRegistrationAttemptQueue" jndiName="jms/HandlingEventRegistrationAttemptQueue">
+    <jmsQueue id="HandlingEventRegistrationAttemptQueue" jndiName="java:app/jms/HandlingEventRegistrationAttemptQueue">
         <properties.wasJms queueName="HandlingEventRegistrationAttemptQueue"/>
     </jmsQueue>
 
@@ -130,7 +130,7 @@
         <properties.wasJms destinationRef="HandlingEventRegistrationAttemptQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
     </jmsActivationSpec>  
 
-    <jmsQueue id="RejectedRegistrationAttemptsQueue" jndiName="jms/RejectedRegistrationAttemptsQueue">
+    <jmsQueue id="RejectedRegistrationAttemptsQueue" jndiName="java:app/jms/RejectedRegistrationAttemptsQueue">
         <properties.wasJms queueName="RejectedRegistrationAttemptsQueue"/>
     </jmsQueue>
 

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -98,7 +98,7 @@
     <jmsQueueConnectionFactory connectionManagerRef="CargoCM" jndiName="java:app/jms/QueueConnectionFactory">
     </jmsQueueConnectionFactory>
 
-    <jmsQueue id="CargoHandledQueue" jndiName="jms/CargoHandledQueue">
+    <jmsQueue id="CargoHandledQueue" jndiName="java:app/jms/CargoHandledQueue">
         <properties.wasJms queueName="CargoHandledQueue"/>
     </jmsQueue>
 
@@ -106,7 +106,7 @@
         <properties.wasJms destinationLookup="java:app/jms/CargoHandledQueue" destinationRef="CargoHandledQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
     </jmsActivationSpec>  
 
-    <jmsQueue id="MisdirectedCargoQueue" jndiName="jms/MisdirectedCargoQueue">
+    <jmsQueue id="MisdirectedCargoQueue" jndiName="java:app/jms/MisdirectedCargoQueue">
         <properties.wasJms queueName="MisdirectedCargoQueue"/>
     </jmsQueue>
 
@@ -114,7 +114,7 @@
         <properties.wasJms destinationRef="MisdirectedCargoQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
     </jmsActivationSpec>  
 
-    <jmsQueue id="DeliveredCargoQueue" jndiName="jms/DeliveredCargoQueue">
+    <jmsQueue id="DeliveredCargoQueue" jndiName="java:app/jms/DeliveredCargoQueue">
         <properties.wasJms queueName="DeliveredCargoQueue"/>
     </jmsQueue>
 
@@ -122,7 +122,7 @@
         <properties.wasJms destinationRef="DeliveredCargoQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
     </jmsActivationSpec>  
 
-    <jmsQueue id="HandlingEventRegistrationAttemptQueue" jndiName="jms/HandlingEventRegistrationAttemptQueue">
+    <jmsQueue id="HandlingEventRegistrationAttemptQueue" jndiName="java:app/jms/HandlingEventRegistrationAttemptQueue">
         <properties.wasJms queueName="HandlingEventRegistrationAttemptQueue"/>
     </jmsQueue>
 
@@ -130,7 +130,7 @@
         <properties.wasJms destinationRef="HandlingEventRegistrationAttemptQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
     </jmsActivationSpec>  
 
-    <jmsQueue id="RejectedRegistrationAttemptsQueue" jndiName="jms/RejectedRegistrationAttemptsQueue">
+    <jmsQueue id="RejectedRegistrationAttemptsQueue" jndiName="java:app/jms/RejectedRegistrationAttemptsQueue">
         <properties.wasJms queueName="RejectedRegistrationAttemptsQueue"/>
     </jmsQueue>
 

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -95,18 +95,18 @@
                maxQueueDepth="5000" />
     </messagingEngine>
 
-    <jmsQueueConnectionFactory connectionManagerRef="CargoCM" jndiName="java:app/jms/QueueConnectionFactory">
+    <jmsQueueConnectionFactory connectionManagerRef="CargoCM" jndiName="jms/QueueConnectionFactory">
     </jmsQueueConnectionFactory>
 
-    <jmsQueue id="CargoHandledQueue" jndiName="java:app/jms/CargoHandledQueue">
+    <jmsQueue id="CargoHandledQueue" jndiName="jms/CargoHandledQueue">
         <properties.wasJms queueName="CargoHandledQueue"/>
     </jmsQueue>
 
     <jmsActivationSpec id="cargo-tracker/CargoHandledConsumer">
-        <properties.wasJms destinationLookup="java:app/jms/CargoHandledQueue" destinationRef="CargoHandledQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
+        <properties.wasJms destinationLookup="jms/CargoHandledQueue" destinationRef="CargoHandledQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
     </jmsActivationSpec>  
 
-    <jmsQueue id="MisdirectedCargoQueue" jndiName="java:app/jms/MisdirectedCargoQueue">
+    <jmsQueue id="MisdirectedCargoQueue" jndiName="jms/MisdirectedCargoQueue">
         <properties.wasJms queueName="MisdirectedCargoQueue"/>
     </jmsQueue>
 
@@ -114,7 +114,7 @@
         <properties.wasJms destinationRef="MisdirectedCargoQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
     </jmsActivationSpec>  
 
-    <jmsQueue id="DeliveredCargoQueue" jndiName="java:app/jms/DeliveredCargoQueue">
+    <jmsQueue id="DeliveredCargoQueue" jndiName="jms/DeliveredCargoQueue">
         <properties.wasJms queueName="DeliveredCargoQueue"/>
     </jmsQueue>
 
@@ -122,7 +122,7 @@
         <properties.wasJms destinationRef="DeliveredCargoQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
     </jmsActivationSpec>  
 
-    <jmsQueue id="HandlingEventRegistrationAttemptQueue" jndiName="java:app/jms/HandlingEventRegistrationAttemptQueue">
+    <jmsQueue id="HandlingEventRegistrationAttemptQueue" jndiName="jms/HandlingEventRegistrationAttemptQueue">
         <properties.wasJms queueName="HandlingEventRegistrationAttemptQueue"/>
     </jmsQueue>
 
@@ -130,7 +130,7 @@
         <properties.wasJms destinationRef="HandlingEventRegistrationAttemptQueue" destinationType="jakarta.jms.Queue" maxConcurrency="200"/>
     </jmsActivationSpec>  
 
-    <jmsQueue id="RejectedRegistrationAttemptsQueue" jndiName="java:app/jms/RejectedRegistrationAttemptsQueue">
+    <jmsQueue id="RejectedRegistrationAttemptsQueue" jndiName="jms/RejectedRegistrationAttemptsQueue">
         <properties.wasJms queueName="RejectedRegistrationAttemptsQueue"/>
     </jmsQueue>
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -64,27 +64,27 @@
     <!-- Defining these at the application server level instead of here can 
 	 be more operations friendly and help make deployment even faster. -->
     <jms-destination>
-        <name>jms/CargoHandledQueue</name>
+        <name>java:app/jms/CargoHandledQueue</name>
         <interface-name>jakarta.jms.Queue</interface-name>
         <destination-name>CargoHandledQueue</destination-name>
     </jms-destination>
     <jms-destination>
-        <name>jms/MisdirectedCargoQueue</name>
+        <name>java:app/jms/MisdirectedCargoQueue</name>
         <interface-name>jakarta.jms.Queue</interface-name>
         <destination-name>MisdirectedCargoQueue</destination-name>
     </jms-destination>
     <jms-destination>
-        <name>jms/DeliveredCargoQueue</name>
+        <name>java:app/jms/DeliveredCargoQueue</name>
         <interface-name>jakarta.jms.Queue</interface-name>
         <destination-name>DeliveredCargoQueue</destination-name>
     </jms-destination>
     <jms-destination>
-        <name>jms/RejectedRegistrationAttemptsQueue</name>
+        <name>java:app/jms/RejectedRegistrationAttemptsQueue</name>
         <interface-name>jakarta.jms.Queue</interface-name>
         <destination-name>RejectedRegistrationAttemptsQueue</destination-name>
     </jms-destination>
     <jms-destination>
-        <name>jms/HandlingEventRegistrationAttemptQueue</name>
+        <name>java:app/jms/HandlingEventRegistrationAttemptQueue</name>
         <interface-name>jakarta.jms.Queue</interface-name>
         <destination-name>HandlingEventRegistrationAttemptQueue</destination-name>
     </jms-destination>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -64,27 +64,27 @@
     <!-- Defining these at the application server level instead of here can 
 	 be more operations friendly and help make deployment even faster. -->
     <jms-destination>
-        <name>java:app/jms/CargoHandledQueue</name>
+        <name>jms/CargoHandledQueue</name>
         <interface-name>jakarta.jms.Queue</interface-name>
         <destination-name>CargoHandledQueue</destination-name>
     </jms-destination>
     <jms-destination>
-        <name>java:app/jms/MisdirectedCargoQueue</name>
+        <name>jms/MisdirectedCargoQueue</name>
         <interface-name>jakarta.jms.Queue</interface-name>
         <destination-name>MisdirectedCargoQueue</destination-name>
     </jms-destination>
     <jms-destination>
-        <name>java:app/jms/DeliveredCargoQueue</name>
+        <name>jms/DeliveredCargoQueue</name>
         <interface-name>jakarta.jms.Queue</interface-name>
         <destination-name>DeliveredCargoQueue</destination-name>
     </jms-destination>
     <jms-destination>
-        <name>java:app/jms/RejectedRegistrationAttemptsQueue</name>
+        <name>jms/RejectedRegistrationAttemptsQueue</name>
         <interface-name>jakarta.jms.Queue</interface-name>
         <destination-name>RejectedRegistrationAttemptsQueue</destination-name>
     </jms-destination>
     <jms-destination>
-        <name>java:app/jms/HandlingEventRegistrationAttemptQueue</name>
+        <name>jms/HandlingEventRegistrationAttemptQueue</name>
         <interface-name>jakarta.jms.Queue</interface-name>
         <destination-name>HandlingEventRegistrationAttemptQueue</destination-name>
     </jms-destination>


### PR DESCRIPTION
Fix issue: https://github.com/Azure-Samples/cargotracker-liberty-aks/issues/28 and [task-6320](https://dev.azure.com/edburns-msft/Open%20Standard%20Enterprise%20Java%20(Java%20EE)%20on%20Azure/_workitems/edit/6302)

## RCA
**`java:app/` prefix should not be used with MDB (Message-Driven Bean) .**

      The Message Flow Architecture:
      Physical Message Queue
              ↓
          JCA Adapter (Running in Global/Server Scope)
              ↓
          MDB (Running in Application Scope)
      
      Key Point: JCA Adapter runs OUTSIDE your application scope!

**The Problem with java:app/**

```
@MessageDriven(
    activationConfig = {
      @ActivationConfigProperty(
          propertyName = "destinationLookup",
          propertyValue = "java:app/jms/MisdirectedCargoQueue")  // ❌ JCA can't see this
    })

```

**Why it fails:**
- java:app/ resources are only visible inside your application
- JCA Adapter runs at server level (outside your application)
- JCA Adapter can't "see" into your application's private JNDI space

## Test

### Confirm that there are no JMS warning logs when running locally
<img width="1115" alt="image" src="https://github.com/user-attachments/assets/5a43efe6-1ba8-4015-95b8-dcdda1c5faba">


### Confirm that the JMS queues are correctly consumed.
1. Check tracking Id: **JKL567**
  -  <img width="864" alt="image" src="https://github.com/user-attachments/assets/89d6391d-9c77-4bed-b749-0b45d0c1b0c0">
2. Add a new message
 -  <img width="458" alt="image" src="https://github.com/user-attachments/assets/65022565-90f1-47eb-920d-a24d920a80d7">
3. Check tracking Id: **JKL567** again
-  <img width="884" alt="image" src="https://github.com/user-attachments/assets/50ded11e-9042-42e6-a36a-37e568dd7a21">



## Followup
The same issue happens when running https://github.com/eclipse-ee4j/cargotracker/  with openliberty