### PR TITLE
Update workflow to support both  `schedule` and `workflow_dispatch` trigger

### DIFF
--- a/.github/workflows/setupOpenLibertyAks.yml
+++ b/.github/workflows/setupOpenLibertyAks.yml
@@ -45,12 +45,22 @@ env:
   resourceGroupForOpenLibertyAks: rg-ol-aks-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
   aksRepoUserName: WASdev
   aksRepoBranchName: 048e776e9efe2ffed8368812e198c1007ba94b2c
+  location: ${{ github.event.inputs.location }}
+  cleanupOptions: ${{ github.event.inputs.cleanupOptions }}
+  deployRequiredSupportingResourcesOnly: ${{ github.event.inputs.deployRequiredSupportingResourcesOnly }}
 
 jobs:
   # Make it so the bicep file that causes Liberty on AKS to be deployed is available to this workflow.
   preflight:
     runs-on: ubuntu-20.04
     steps:
+      # if the workflow is triggered by a schedule event, update the environment variables.
+      - name: Update environment variables if triggered by a schedule event
+        if: github.event_name == 'schedule'
+        run: |
+          echo "location=westus" >> $GITHUB_ENV
+          echo "cleanupOptions=delete_immediately" >> $GITHUB_ENV
+          echo "deployRequiredSupportingResourcesOnly=false" >> $GITHUB_ENV
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/v0.29.47/bicep-linux-x64
@@ -114,7 +124,7 @@ jobs:
           azcliversion: ${{ env.azCliVersion }}
           inlineScript: |
             echo "create resource group" ${{ env.resourceGroupForDB }}
-            az group create --verbose --name ${{ env.resourceGroupForDB }} --location ${{ inputs.location }}
+            az group create --verbose --name ${{ env.resourceGroupForDB }} --location ${{ env.location }}
       - name: Set Up Azure Postgresql to Test dbTemplate
         id: setup-postgresql
         uses: azure/CLI@v1
@@ -125,7 +135,7 @@ jobs:
             az postgres flexible-server create \
             --resource-group ${{ env.resourceGroupForDB }} \
             --name ${{ env.dbServerName }} \
-            --location ${{ inputs.location }} \
+            --location ${{ env.location }} \
             --admin-user ${{ env.dbAdminUser }} \
             --admin-password ${{ env.dbPassword }} \
             --version 16 \
@@ -160,7 +170,7 @@ jobs:
   deploy-openliberty-on-aks:
     needs: preflight
     runs-on: ubuntu-20.04
-    if: ${{ inputs.deployRequiredSupportingResourcesOnly == false }}
+    if: ${{ env.deployRequiredSupportingResourcesOnly == false }}
     steps:
       - name: Checkout ${{ env.aksRepoUserName }}/azure.liberty.aks
         uses: actions/checkout@v2
@@ -203,7 +213,7 @@ jobs:
           azcliversion: ${{ env.azCliVersion }}
           inlineScript: |
             echo "create resource group" ${{ env.resourceGroupForOpenLibertyAks }}
-            az group create --verbose --name ${{ env.resourceGroupForOpenLibertyAks }} --location ${{ inputs.location }}
+            az group create --verbose --name ${{ env.resourceGroupForOpenLibertyAks }} --location ${{ env.location }}
       - name: Checkout cargotracker
         uses: actions/checkout@v2
         with:
@@ -211,7 +221,7 @@ jobs:
       - name: Prepare parameter file
         run: |
           echo "replace placeholders using real parameter"
-          sed -i "s/#location#/${{ inputs.location }}/g; \
+          sed -i "s/#location#/${{ env.location }}/g; \
                   s/#testbranchName#/${aksRepoBranchName}/g; \
                   s/#gitUserName#/${aksRepoUserName}/g" \
                   cargotracker/src/test/aks/parameters.json
@@ -249,7 +259,7 @@ jobs:
   deploy-azure-monitor:
     needs: [preflight, deploy-openliberty-on-aks]
     runs-on: ubuntu-20.04
-    if: ${{ inputs.deployRequiredSupportingResourcesOnly == false }}
+    if: ${{ env.deployRequiredSupportingResourcesOnly == false }}
     steps:
       - uses: azure/login@v1
         id: azure-login
@@ -264,7 +274,7 @@ jobs:
             az monitor log-analytics workspace create \
               --resource-group ${{ env.resourceGroupForOpenLibertyAks }} \
               --workspace-name ${{ env.workspaceName }} \
-              --location ${{ inputs.location }}
+              --location ${{ env.location }}
       - name: Enable Container Insights
         id: enable-container-insights
         uses: azure/CLI@v1
@@ -291,13 +301,13 @@ jobs:
             az monitor app-insights component create \
               --resource-group ${{ env.resourceGroupForOpenLibertyAks }} \
               --app ${{ env.appInsightsName }} \
-              --location ${{ inputs.location }} \
+              --location ${{ env.location }} \
               --workspace ${workspaceId}
   # Build app, push to ACR and apply it to Open Liberty servers running on AKS.
   deploy-cargo-tracker:
     needs: [preflight, deploy-db,deploy-azure-monitor]
     runs-on: ubuntu-20.04
-    if: ${{ inputs.deployRequiredSupportingResourcesOnly == false }}
+    if: ${{ env.deployRequiredSupportingResourcesOnly == false }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -506,25 +516,25 @@ jobs:
           creds: ${{ env.azureCredentials }}
       - name: Handle cleanup options
         run: |
-          if [ "${{ github.event.inputs.cleanupOptions }}" == "delete_immediately" ]; then
+          if [ "${{ env.cleanupOptions }}" == "delete_immediately" ]; then
             echo "Resources will be deleted immediately."
-          elif [ "${{ github.event.inputs.cleanupOptions }}" == "delete_after_30m" ]; then
+          elif [ "${{ env.cleanupOptions }}" == "delete_after_30m" ]; then
             echo "Sleeping for 30m before deleting resources."
             sleep 30m
-          elif [ "${{ github.event.inputs.cleanupOptions }}" == "delete_after_2hours" ]; then
+          elif [ "${{ env.cleanupOptions }}" == "delete_after_2hours" ]; then
             echo "Sleeping for 2h before deleting resources."
             sleep 2h
-          elif [ "${{ github.event.inputs.cleanupOptions }}" == "delete_after_5hours" ]; then
+          elif [ "${{ env.cleanupOptions }}" == "delete_after_5hours" ]; then
             echo "Sleeping for 5h before deleting resources."
             sleep 5h
-          elif [ "${{ github.event.inputs.cleanupOptions }}" == "never_delete" ]; then
+          elif [ "${{ env.cleanupOptions }}" == "never_delete" ]; then
             echo "Resources will not be deleted automatically."
             exit 0
           fi
 
       - name: Delete Azure resources.
         uses: azure/CLI@v1
-        if: ${{ github.event.inputs.cleanupOptions  != 'never_delete' }}
+        if: ${{ env.cleanupOptions  != 'never_delete' }}
         with:
           azcliversion: ${{ env.azCliVersion }}
           inlineScript: |

--- a/.github/workflows/setupOpenLibertyAks.yml
+++ b/.github/workflows/setupOpenLibertyAks.yml
@@ -170,8 +170,12 @@ jobs:
   deploy-openliberty-on-aks:
     needs: preflight
     runs-on: ubuntu-20.04
-    if: env.deployRequiredSupportingResourcesOnly == 'false'
     steps:
+      - name: check whether to skip current job
+        if: env.deployRequiredSupportingResourcesOnly == 'ture'
+        run: |
+          echo "skip current job"
+          exit 0
       - name: Checkout ${{ env.aksRepoUserName }}/azure.liberty.aks
         uses: actions/checkout@v2
         with:
@@ -259,8 +263,12 @@ jobs:
   deploy-azure-monitor:
     needs: [preflight, deploy-openliberty-on-aks]
     runs-on: ubuntu-20.04
-    if: env.deployRequiredSupportingResourcesOnly == 'false'
     steps:
+      - name: check whether to skip current job
+        if: env.deployRequiredSupportingResourcesOnly == 'ture'
+        run: |
+          echo "skip current job"
+          exit 0
       - uses: azure/login@v1
         id: azure-login
         with:
@@ -307,8 +315,12 @@ jobs:
   deploy-cargo-tracker:
     needs: [preflight, deploy-db,deploy-azure-monitor]
     runs-on: ubuntu-20.04
-    if: env.deployRequiredSupportingResourcesOnly == 'false'
     steps:
+      - name: check whether to skip current job
+        if: env.deployRequiredSupportingResourcesOnly == 'ture'
+        run: |
+          echo "skip current job"
+          exit 0
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/setupOpenLibertyAks.yml
+++ b/.github/workflows/setupOpenLibertyAks.yml
@@ -170,7 +170,7 @@ jobs:
   deploy-openliberty-on-aks:
     needs: preflight
     runs-on: ubuntu-20.04
-    if: ${{ env.deployRequiredSupportingResourcesOnly == false }}
+    if: env.deployRequiredSupportingResourcesOnly == 'false'
     steps:
       - name: Checkout ${{ env.aksRepoUserName }}/azure.liberty.aks
         uses: actions/checkout@v2
@@ -259,7 +259,7 @@ jobs:
   deploy-azure-monitor:
     needs: [preflight, deploy-openliberty-on-aks]
     runs-on: ubuntu-20.04
-    if: ${{ env.deployRequiredSupportingResourcesOnly == false }}
+    if: env.deployRequiredSupportingResourcesOnly == 'false'
     steps:
       - uses: azure/login@v1
         id: azure-login
@@ -307,7 +307,7 @@ jobs:
   deploy-cargo-tracker:
     needs: [preflight, deploy-db,deploy-azure-monitor]
     runs-on: ubuntu-20.04
-    if: ${{ env.deployRequiredSupportingResourcesOnly == false }}
+    if: env.deployRequiredSupportingResourcesOnly == 'false'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/setupOpenLibertyAks.yml
+++ b/.github/workflows/setupOpenLibertyAks.yml
@@ -26,8 +26,7 @@ on:
         default: false
   repository_dispatch:
   schedule:
-#    - cron: '0 0 27 * *' # run the workflow at the end of 27th monthly.
-    - cron: '*/5 * * * *'  # This will run every 5 minutes, only used for test
+    - cron: '0 0 27 * *' # run the workflow at the end of 27th monthly.
 
 env:
   refArmttk: c11a62d4ae011ee96fdecc76d76d811c5b5a99ce

--- a/.github/workflows/setupOpenLibertyAks.yml
+++ b/.github/workflows/setupOpenLibertyAks.yml
@@ -46,22 +46,29 @@ env:
   resourceGroupForOpenLibertyAks: rg-ol-aks-${{ github.repository_owner }}-${{ github.run_id }}-${{ github.run_number }}
   aksRepoUserName: WASdev
   aksRepoBranchName: 048e776e9efe2ffed8368812e198c1007ba94b2c
-  location: ${{ github.event.inputs.location }}
-  cleanupOptions: ${{ github.event.inputs.cleanupOptions }}
-  deployRequiredSupportingResourcesOnly: ${{ github.event.inputs.deployRequiredSupportingResourcesOnly }}
 
 jobs:
   # Make it so the bicep file that causes Liberty on AKS to be deployed is available to this workflow.
   preflight:
     runs-on: ubuntu-20.04
+    outputs:
+      location: ${{ steps.update-env.outputs.location }}
+      cleanupOptions: ${{ steps.update-env.outputs.cleanupOptions }}
+      deployRequiredSupportingResourcesOnly: ${{ steps.update-env.outputs.deployRequiredSupportingResourcesOnly }}
     steps:
       # if the workflow is triggered by a schedule event, update the environment variables.
       - name: Update environment variables if triggered by a schedule event
-        if: github.event_name == 'schedule'
+        id: update-env
         run: |
-          echo "location=westus" >> $GITHUB_ENV
-          echo "cleanupOptions=delete_immediately" >> $GITHUB_ENV
-          echo "deployRequiredSupportingResourcesOnly=false" >> $GITHUB_ENV
+          if [ "${{ github.event_name }}" == "schedule" ]; then
+           echo "::set-output name=location::westus"
+           echo "::set-output name=cleanupOptions::delete_immediately"
+           echo "::set-output name=deployRequiredSupportingResourcesOnly::false"
+          else
+           echo "::set-output name=location::${{ github.event.inputs.location }}"
+           echo "::set-output name=cleanupOptions::${{ github.event.inputs.cleanupOptions }}"
+           echo "::set-output name=deployRequiredSupportingResourcesOnly::${{ github.event.inputs.deployRequiredSupportingResourcesOnly }}"
+          fi
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/v0.29.47/bicep-linux-x64
@@ -125,7 +132,7 @@ jobs:
           azcliversion: ${{ env.azCliVersion }}
           inlineScript: |
             echo "create resource group" ${{ env.resourceGroupForDB }}
-            az group create --verbose --name ${{ env.resourceGroupForDB }} --location ${{ env.location }}
+            az group create --verbose --name ${{ env.resourceGroupForDB }} --location ${{ needs.preflight.outputs.location }}
       - name: Set Up Azure Postgresql to Test dbTemplate
         id: setup-postgresql
         uses: azure/CLI@v1
@@ -136,7 +143,7 @@ jobs:
             az postgres flexible-server create \
             --resource-group ${{ env.resourceGroupForDB }} \
             --name ${{ env.dbServerName }} \
-            --location ${{ env.location }} \
+            --location ${{ needs.preflight.outputs.location }} \
             --admin-user ${{ env.dbAdminUser }} \
             --admin-password ${{ env.dbPassword }} \
             --version 16 \
@@ -173,7 +180,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: check whether to skip current job
-        if: env.deployRequiredSupportingResourcesOnly == 'ture'
+        if: ${{ needs.preflight.outputs.deployRequiredSupportingResourcesOnly == 'ture' }}
         run: |
           echo "skip current job"
           exit 0
@@ -218,7 +225,7 @@ jobs:
           azcliversion: ${{ env.azCliVersion }}
           inlineScript: |
             echo "create resource group" ${{ env.resourceGroupForOpenLibertyAks }}
-            az group create --verbose --name ${{ env.resourceGroupForOpenLibertyAks }} --location ${{ env.location }}
+            az group create --verbose --name ${{ env.resourceGroupForOpenLibertyAks }} --location ${{ needs.preflight.outputs.location }}
       - name: Checkout cargotracker
         uses: actions/checkout@v2
         with:
@@ -226,7 +233,7 @@ jobs:
       - name: Prepare parameter file
         run: |
           echo "replace placeholders using real parameter"
-          sed -i "s/#location#/${{ env.location }}/g; \
+          sed -i "s/#location#/${{ needs.preflight.outputs.location }}/g; \
                   s/#testbranchName#/${aksRepoBranchName}/g; \
                   s/#gitUserName#/${aksRepoUserName}/g" \
                   cargotracker/src/test/aks/parameters.json
@@ -266,7 +273,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: check whether to skip current job
-        if: env.deployRequiredSupportingResourcesOnly == 'ture'
+        if: ${{ needs.preflight.outputs.deployRequiredSupportingResourcesOnly == 'ture' }}
         run: |
           echo "skip current job"
           exit 0
@@ -283,7 +290,7 @@ jobs:
             az monitor log-analytics workspace create \
               --resource-group ${{ env.resourceGroupForOpenLibertyAks }} \
               --workspace-name ${{ env.workspaceName }} \
-              --location ${{ env.location }}
+              --location ${{ needs.preflight.outputs.location }}
       - name: Enable Container Insights
         id: enable-container-insights
         uses: azure/CLI@v1
@@ -310,7 +317,7 @@ jobs:
             az monitor app-insights component create \
               --resource-group ${{ env.resourceGroupForOpenLibertyAks }} \
               --app ${{ env.appInsightsName }} \
-              --location ${{ env.location }} \
+              --location ${{ needs.preflight.outputs.location }} \
               --workspace ${workspaceId}
   # Build app, push to ACR and apply it to Open Liberty servers running on AKS.
   deploy-cargo-tracker:
@@ -318,7 +325,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: check whether to skip current job
-        if: env.deployRequiredSupportingResourcesOnly == 'ture'
+        if: ${{ needs.preflight.outputs.deployRequiredSupportingResourcesOnly == 'ture' }}
         run: |
           echo "skip current job"
           exit 0
@@ -529,18 +536,18 @@ jobs:
           creds: ${{ env.azureCredentials }}
       - name: Handle cleanup options
         run: |
-          if [ "${{ env.cleanupOptions }}" == "delete_immediately" ]; then
+          if [ "${{ needs.preflight.outputs.cleanupOptions }}" == "delete_immediately" ]; then
             echo "Resources will be deleted immediately."
-          elif [ "${{ env.cleanupOptions }}" == "delete_after_30m" ]; then
+          elif [ "${{ needs.preflight.outputs.cleanupOptions }}" == "delete_after_30m" ]; then
             echo "Sleeping for 30m before deleting resources."
             sleep 30m
-          elif [ "${{ env.cleanupOptions }}" == "delete_after_2hours" ]; then
+          elif [ "${{ needs.preflight.outputs.cleanupOptions }}" == "delete_after_2hours" ]; then
             echo "Sleeping for 2h before deleting resources."
             sleep 2h
-          elif [ "${{ env.cleanupOptions }}" == "delete_after_5hours" ]; then
+          elif [ "${{ needs.preflight.outputs.cleanupOptions }}" == "delete_after_5hours" ]; then
             echo "Sleeping for 5h before deleting resources."
             sleep 5h
-          elif [ "${{ env.cleanupOptions }}" == "never_delete" ]; then
+          elif [ "${{ needs.preflight.outputs.cleanupOptions }}" == "never_delete" ]; then
             echo "Resources will not be deleted automatically."
             exit 0
           fi

--- a/.github/workflows/setupOpenLibertyAks.yml
+++ b/.github/workflows/setupOpenLibertyAks.yml
@@ -524,7 +524,7 @@ jobs:
           echo "${appURL}" >> $GITHUB_STEP_SUMMARY
  # Delete azure resources
   cleanup:
-    name: provisioned resources will ${{ inputs.cleanupOptions }} automatically
+    name: provisioned resources will ${{ needs.preflight.outputs.cleanupOptions }} automatically
     if: always()
     needs: [preflight, deploy-db, deploy-openliberty-on-aks, deploy-azure-monitor, deploy-cargo-tracker]
     runs-on: ubuntu-latest
@@ -553,7 +553,7 @@ jobs:
 
       - name: Delete Azure resources.
         uses: azure/CLI@v1
-        if: ${{ env.cleanupOptions  != 'never_delete' }}
+        if: ${{ needs.preflight.outputs.cleanupOptions  != 'never_delete' }}
         with:
           azcliversion: ${{ env.azCliVersion }}
           inlineScript: |

--- a/.github/workflows/setupOpenLibertyAks.yml
+++ b/.github/workflows/setupOpenLibertyAks.yml
@@ -26,7 +26,8 @@ on:
         default: false
   repository_dispatch:
   schedule:
-    - cron: '0 0 27 * *' # run the workflow at the end of 27th monthly.
+#    - cron: '0 0 27 * *' # run the workflow at the end of 27th monthly.
+    - cron: '*/5 * * * *'  # This will run every 5 minutes, only used for test
 
 env:
   refArmttk: c11a62d4ae011ee96fdecc76d76d811c5b5a99ce


### PR DESCRIPTION
## Context
Refer to [6457](https://dev.azure.com/edburns-msft/Open%20Standard%20Enterprise%20Java%20(Java%20EE)%20on%20Azure/_workitems/edit/6457)
There are two ways to run the cargotracker-liberty-aks workflow.
- Trigger manually, it contains parameters with **default** value.
- Scheduled to run, it contains parameters with **null/empty** value.

The cargotracker-liberty-aks workflow has changed a lot since created and the running depends on the parameters set in workflow_dispatch, but the values are not properly set with the scheduled running.

## Goal
The PR is used to fix the issue by setting the same default value.


## Test Result
### Test manually
https://github.com/azure-javaee/cargotracker-liberty-aks/actions/runs/12071784291
✅ <img width="935" alt="image" src="https://github.com/user-attachments/assets/5ecbb6f9-5aac-40d2-9e83-6ab6d62524fb">


### Test `schedule` 
✅ https://github.com/azure-javaee/cargotracker-liberty-aks/actions/runs/12070918334
<img width="855" alt="image" src="https://github.com/user-attachments/assets/e3b7b641-c376-4a74-a9a1-fb6454e66917">

